### PR TITLE
Updated runtime version to 23.08

### DIFF
--- a/io.github.naikari.Naikari.yaml
+++ b/io.github.naikari.Naikari.yaml
@@ -1,6 +1,6 @@
 id: io.github.naikari.Naikari
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: naikari
 finish-args:


### PR DESCRIPTION
I'm having trouble finding documentation for what I'm supposed to do to solve this "end-of-life" warning, but https://docs.flatpak.org/en/latest/available-runtimes.html seems to be suggesting version 23.08, so… I'll see if it works, I guess? 🤷🏼‍♀️