### PR TITLE
Added a patch to disable insertion of the word "dirty" into the versi…

### DIFF
--- a/disable-dirty.patch
+++ b/disable-dirty.patch
@@ -1,0 +1,12 @@
+diff --git a/utils/build/gen_version.sh b/utils/build/gen_version.sh
+index db719216d5..59d09c8a6f 100755
+--- a/utils/build/gen_version.sh
++++ b/utils/build/gen_version.sh
+@@ -5,7 +5,7 @@ VERSION=""
+ 
+ if [ -d "$SOURCE_ROOT/.git/" ]; then
+     # In the git repo. Build the tag from git info
+-    VERSION=$(git -C "$SOURCE_ROOT" describe --tags --match 'v*' --dirty | sed -E 's/^v//;s/^(.*)-([^-]*)-(g[^-]*)/\1+\2.\3/;s/-dirty/.dirty/')
++    VERSION=$(git -C "$SOURCE_ROOT" describe --tags --match 'v*' | sed -E 's/^v//;s/^(.*)-([^-]*)-(g[^-]*)/\1+\2.\3/;s/-dirty/.dirty/')
+     echo "$VERSION" > "$SOURCE_ROOT/dat/VERSION"
+ fi

--- a/io.github.naikari.Naikari.yaml
+++ b/io.github.naikari.Naikari.yaml
@@ -109,3 +109,5 @@ modules:
           stable-only: true
       - type: patch
         path: metainfo-release-tag-fix.patch
+      - type: patch
+        path: disable-dirty.patch


### PR DESCRIPTION
…on number.

This should "fix" a bug that causes the build to not run (due to ".dirty" getting appended to a release version number being invalid according to semver spec). This is not the proper way to do it by any means, but I don't have any sed experience and it doesn't look like I'll be able to figure out how to use sed tonight.